### PR TITLE
테스트 정리한다

### DIFF
--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -5,22 +5,30 @@ end
 require 'pry'
 require_relative './helpers/spec_helper'
 
-describe Md2Html::Parser do
+describe Md2Html::Parser, "parsesr" do
 
-  it "inline_parser can parse bold, emphasis, dash element, which are inline elements" do
+  it "can parse tokens that has bold tag" do
     parser = Md2Html::Parser::ParserFactory.build(:inline_parser)
 
     bold_token = Md2Html::Tokenizer::tokenize("**foo**")
     expect(parser.match(bold_token)).to eq_node(Md2Html::Parser::Node.new(type: 'BOLD', value: bold_token.third.value, consumed: 5))
+  end
+
+  it "can parse tokens that has emphasis tag" do
+    parser = Md2Html::Parser::ParserFactory.build(:inline_parser)
 
     emphasis_token = Md2Html::Tokenizer::tokenize("*foo*")
     expect(parser.match(emphasis_token)).to eq_node(Md2Html::Parser::Node.new(type: 'EMPHASIS', value: emphasis_token.second.value, consumed: 3))
+  end
+
+  it "can parse tokens that has dash tag" do
+    parser = Md2Html::Parser::ParserFactory.build(:inline_parser)
 
     dash_token = Md2Html::Tokenizer::tokenize("-")
     expect(parser.match(dash_token)).to eq_node(Md2Html::Parser::Node.new(type: 'DASH', value: dash_token.first.value, consumed: 1))
   end
 
-  it "list_items_parser can parse list items ends with eof or newline" do
+  it "can parse list items ends with newline and eof" do
     parser = Md2Html::Parser::ParserFactory.build(:list_items_parser)
 
     list_nl_eof_token = Md2Html::Tokenizer::tokenize("- foo\n")
@@ -29,6 +37,10 @@ describe Md2Html::Parser do
         sentences: Md2Html::Parser::Node.new(type: 'LIST_ITEM', value: ' foo', consumed: 3),
         consumed: 4)
     )
+  end
+
+  it "can parse list items ends with two newlines and eof" do
+    parser = Md2Html::Parser::ParserFactory.build(:list_items_parser)
 
     list_nl_nl_eof_token = Md2Html::Tokenizer::tokenize("- foo\n\n")
     expect(parser.match(list_nl_nl_eof_token)).to eq_list_node(
@@ -36,6 +48,10 @@ describe Md2Html::Parser do
         sentences: Md2Html::Parser::Node.new(type: 'LIST_ITEM', value: ' foo', consumed: 3),
         consumed: 5)
     )
+  end
+
+  it "can parse multiple list items ends with eof or newline" do
+    parser = Md2Html::Parser::ParserFactory.build(:list_items_parser)
 
     list_nl_list_nl_eof_token = Md2Html::Tokenizer::tokenize("- foo\n- bar\n")
     expect(parser.match(list_nl_list_nl_eof_token)).to eq_list_node(
@@ -60,24 +76,10 @@ describe Md2Html::Parser do
     expect(nodes.consumed).to eq 3
   end
 
-  it "list_item_parser parse one list item" do
-    tokens = Md2Html::Tokenizer::tokenize("- foo\n")
-    parser = Md2Html::Parser::ParserFactory.build(:list_item_parser)
-    nodes = parser.match(tokens)
-    expect(nodes.consumed).to eq 3
-  end
-
   it "parse 1 list item and newline" do
     tokens = Md2Html::Tokenizer::tokenize("- foo\n")
     nodes = Md2Html::Parser::parse(tokens)
     expect(nodes.consumed).to eq 4
-  end
-
-  it "list_items_and_eof_parser parse list items of the same level" do
-    tokens = Md2Html::Tokenizer::tokenize("- foo\n- bar\n- baz\n")
-    parser = Md2Html::Parser::ParserFactory.build(:list_items_parser)
-    nodes = parser.match(tokens)
-    expect(nodes.consumed).to eq 10 #(dash text newline) * 3 + eof
   end
 
   it "parse list items of the same level" do


### PR DESCRIPTION
 - inline parser, list items parser 테스트를 케이스 별로 구분한다
 - inline parser, list items parser 테스트를 추가하면서 제외해도 괜찮은 테스트를 삭제한다