### PR TITLE
단락 구분 로직을 개선한다

### DIFF
--- a/lib/md2html/parser/paragraph_parser.rb
+++ b/lib/md2html/parser/paragraph_parser.rb
@@ -14,6 +14,14 @@ module Md2Html
           return Node.null
         end
 
+        ends_early = sentences.find_index {|s| s.type == 'SENTENCE_ENDS_EARLY'}
+        if ends_early != nil
+          return ParagraphNode.new(
+            sentences: sentences[0..ends_early],
+            consumed: sentences[0..ends_early].inject(0) {|new_consumed, sentence| new_consumed + sentence.consumed}
+          )
+        end
+
         ParagraphNode.new(sentences: sentences, consumed: consumed)
       end
     end

--- a/lib/md2html/parser/sentence_node.rb
+++ b/lib/md2html/parser/sentence_node.rb
@@ -1,11 +1,19 @@
 module Md2Html
   module Parser
     class SentenceNode
-      attr_reader :words, :consumed, :type
-      def initialize(words:, consumed:)
-        @words = words
-        @consumed  = consumed
-        @type = 'SENTENCE'
+      attr_reader :words, :consumed
+      attr_accessor :type
+
+      def initialize(options = {})
+        @words = options[:words]
+        @consumed  = options[:consumed]
+        @type = options[:type] || 'SENTENCE'
+      end
+
+      def self.ends_early(options = {})
+        sentence = SentenceNode.new(options)
+        sentence.type = 'SENTENCE_ENDS_EARLY'
+        sentence
       end
 
       def to_s

--- a/lib/md2html/parser/sentence_parser.rb
+++ b/lib/md2html/parser/sentence_parser.rb
@@ -17,6 +17,7 @@ module Md2Html
           consumed += 3
         when tokens.peek_from(consumed, 'NEWLINE', 'NEWLINE') == true
           consumed += 2
+          return SentenceNode.ends_early({words: nodes, consumed: consumed})
         when tokens.peek_from(consumed, 'NEWLINE', 'EOF') == true
           consumed += 2
         when tokens.peek_from(consumed, 'NEWLINE') == true

--- a/md2html.gemspec
+++ b/md2html.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name                  = %q{md2html}
-  s.version               = "0.0.0"
+  s.version               = "0.1.0"
   s.description           = %q{A simple markdown to html converter}
   s.date                  = %q{2024-03-26}
 

--- a/spec/generator_spec.rb
+++ b/spec/generator_spec.rb
@@ -35,6 +35,15 @@ describe Md2Html::Generator do
 </p>\n"
   end
 
+  fit "generates html from two paragraph" do
+    expect(generate("__Foo__ and *text*.\n\nAnother para.")).to eq "<p>
+  <strong>Foo</strong> and <em>text</em>.
+</p>
+<p>
+  Another para.
+</p>\n"
+  end
+
   it "generates html from 1 list item" do
     expect(generate("- foo\n")).to eq "<ul>
   <li>foo</li>

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -274,11 +274,10 @@ describe Md2Html::Parser, "parser" do
       expect(paragraph_node.consumed).to eq 3
     end
 
-    fit "can parse two paragraphs" do
+    it "can parse two paragraphs" do
       parser = create_parser(:body_parser)
 
       tokens = tokenize("**Foo**\n\nAnother para.")
-      p tokens
       body_node = parser.match(tokens)
 
       expect(body_node).to eq_body_node(

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -165,7 +165,7 @@ describe Md2Html::Parser, "parser" do
             create_node(type: 'TEXT', value: ' and ', consumed: 1),
             create_node(type: 'EMPHASIS', value: 'text', consumed: 3),
             create_node(type: 'TEXT', value: '.', consumed: 1),
-            create_node(type: 'NEWLINE', value: '\n', consumed: 2)
+            create_node(type: 'NEWLINE', value: '\n', consumed: 1)
           ], consumed: 12),
           create_sentence_node(words: [
             create_node(type: 'BOLD', value: 'Foo', consumed: 5),
@@ -348,7 +348,7 @@ describe Md2Html::Parser, "parser" do
                   create_node(type: 'TEXT', value: ' and ', consumed: 1),
                   create_node(type: 'EMPHASIS', value: 'text', consumed: 3),
                   create_node(type: 'TEXT', value: '.', consumed: 1),
-                  create_node(type: 'NEWLINE', value: '\n', consumed: 2)
+                  create_node(type: 'NEWLINE', value: '\n', consumed: 1)
                 ], consumed: 12),
                 create_sentence_node(words: [
                   create_node(type: 'TEXT', value: 'Another para.', consumed: 1),

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -234,13 +234,49 @@ describe Md2Html::Parser, "parser" do
     end
   end
 
-  it "body parser parse text that has dash character" do
-    parser = create_parser(:body_parser)
+  context "body parser" do
+    it "can parse text that has dash character" do
+      parser = create_parser(:body_parser)
 
-    tokens = tokenize("- foo")
-    paragraph_node = parser.match(tokens)
+      tokens = tokenize("- foo")
+      paragraph_node = parser.match(tokens)
 
-    expect(paragraph_node.consumed).to eq 3
+      expect(paragraph_node.consumed).to eq 3
+    end
+
+    fit "can parse two paragraphs" do
+      parser = create_parser(:body_parser)
+
+      tokens = tokenize("**Foo**\n\nAnother para.")
+      p tokens
+      body_node = parser.match(tokens)
+
+      expect(body_node).to eq_body_node(
+        create_body_node(
+          blocks:[
+            create_paragraph_node(
+              sentences: [
+                create_sentence_node(words: [
+                  create_node(type: 'BOLD', value: 'Foo', consumed: 5),
+                  create_node(type: 'NEWLINE', value: '\n', consumed: 2),
+                  create_node(type: 'NEWLINE', value: '\n', consumed: 2)
+                ], consumed: 9),
+              ],
+              consumed: 9
+            ),
+            create_paragraph_node(
+              sentences: [
+                create_sentence_node(words: [
+                  create_node(type: 'TEXT', value: 'Another para.', consumed: 1),
+                ], consumed: 1),
+              ],
+              consumed: 2
+            )
+          ],
+          consumed: 11
+        )
+      )
+    end
   end
 
   context "with parser chain" do

--- a/test/data/paragraph/one_para_with_br.html
+++ b/test/data/paragraph/one_para_with_br.html
@@ -1,0 +1,3 @@
+<p>
+  <strong>Foo</strong> and <em>text</em>.<br>Another para.
+</p>

--- a/test/data/paragraph/one_para_with_br.md
+++ b/test/data/paragraph/one_para_with_br.md
@@ -1,3 +1,2 @@
 __Foo__ and *text*.
-
 Another para.

--- a/test/data/paragraph/two_para.html
+++ b/test/data/paragraph/two_para.html
@@ -1,3 +1,6 @@
 <p>
-  <strong>Foo</strong> and <em>text</em>.<br>Another para.
+  <strong>Foo</strong> and <em>text</em>.
+</p>
+<p>
+  Another para.
 </p>

--- a/test/run_tests.rb
+++ b/test/run_tests.rb
@@ -3,7 +3,7 @@ require 'test/unit'
 
 include Test::Unit::Assertions
 
-paths = ['bold/bold', 'paragraph/one_para', 'paragraph/two_para', 'list/list', 'escape/escape', 'heading/level_1']
+paths = ['bold/bold', 'paragraph/one_para', 'paragraph/one_para_with_br', 'paragraph/two_para', 'list/list', 'escape/escape', 'heading/level_1']
 paths.each do |path|
   # 마크다운 포맷 테스트 데이터를 읽어온다
   # 읽어온 데이터에 md2html.make_html 메서드를 적용한다
@@ -12,6 +12,6 @@ paths.each do |path|
   # html 포맷 테스트 데이터를 읽어온다
   html_file = File.read(File.expand_path("test/data/#{path}.html"))
 
-  assert_equal(html_file, Md2Html::make_html(md_file))
   # md2html.make_html 적용된 결과와 비교한다
+  assert_equal(html_file, Md2Html::make_html(md_file))
 end


### PR DESCRIPTION
다음처럼 파싱할 수 있도록 로직을 개선한다
- [nl 없이 이어진 여러 문장][nl][nl 없이 이어진 여러 문장] => [paragraph]
- [nl 없이 이어진 여러 문장][nl][nl][nl 없이 이어진 여러 문장] => [paragraph1][paragraph2]