### PR TITLE
특수 문자를 escape 처리할 수 있다

### DIFF
--- a/lib/md2html/tokenizer.rb
+++ b/lib/md2html/tokenizer.rb
@@ -18,7 +18,24 @@ module Md2Html
 
     def self.tokenize(plain_markdown)
       tokens_array = tokens_as_array(plain_markdown)
-      Tokenizer::TokenList.new(tokens_array)
+      merged_tokens = merge_chars2escape(tokens_array)
+      Tokenizer::TokenList.new(merged_tokens)
+    end
+
+    def self.merge_chars2escape(tokens_array)
+      merged_tokens = []
+      tokens_array.each.with_index do |token, idx|
+        if idx != 0 and tokens_array[idx - 1].type == 'ESCAPE'
+          next
+        end
+
+        if token.type == 'ESCAPE'
+          merged_tokens <<  Tokenizer::Token.new(type: 'TEXT', value: tokens_array[idx + 1].value)
+        else
+          merged_tokens << token
+        end
+      end
+      merged_tokens
     end
 
     private

--- a/lib/md2html/tokenizer.rb
+++ b/lib/md2html/tokenizer.rb
@@ -25,11 +25,11 @@ module Md2Html
 
     def self.tokens_as_array(plain_markdown)
       if plain_markdown.nil? || plain_markdown == ''
-        [Tokenizer::Token.end_of_file]
-      else
-        token = scan_one_token(plain_markdown)
-        [token] + tokens_as_array(plain_markdown[token.length..-1])
+        return [Tokenizer::Token.end_of_file]
       end
+
+      token = scan_one_token(plain_markdown)
+      [token] + tokens_as_array(plain_markdown[token.length..-1])
     end
 
     def self.scan_one_token(plain_markdown)

--- a/lib/md2html/tokenizer/simple_scanner.rb
+++ b/lib/md2html/tokenizer/simple_scanner.rb
@@ -14,7 +14,8 @@ module Md2Html
         '-'  => 'DASH',
         '*'  => 'STAR',
         "\n" => 'NEWLINE',
-        '#'  => 'HASH'
+        '#'  => 'HASH',
+        "\\" => 'ESCAPE'
       }.freeze
 
       def self.from_string(plain_markdown)

--- a/spec/generator_spec.rb
+++ b/spec/generator_spec.rb
@@ -35,7 +35,7 @@ describe Md2Html::Generator do
 </p>\n"
   end
 
-  fit "generates html from two paragraph" do
+  it "generates html from two paragraph" do
     expect(generate("__Foo__ and *text*.\n\nAnother para.")).to eq "<p>
   <strong>Foo</strong> and <em>text</em>.
 </p>

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -150,9 +150,39 @@ describe Md2Html::Parser, "parser" do
       sentence_node = parser.match(token_nl_nl)
       expect(sentence_node).to eq_sentence_node create_sentence_node(words: expected_words, consumed: 13)
     end
+
+    it "can parse tokens that has escaped special char" do
+      parser = create_parser(:sentence_parser)
+      expected_words = [
+        create_node(type: 'TEXT', value: '-', consumed: 1),
+        create_node(type: 'TEXT', value: ' blah blah', consumed: 1)
+      ]
+
+      tokens = tokenize("\\- blah blah")
+      sentence_node = parser.match(tokens)
+      expect(sentence_node).to eq_sentence_node create_sentence_node(
+        words: expected_words, consumed: 3
+      )
+    end
   end
 
   context "paragraph parser" do
+    it "can parse tokens that has escaped special char" do
+      parser = create_parser(:block_parser)
+
+      tokens = tokenize("\\- blah blah")
+      paragraph_node = parser.match(tokens)
+      expect(paragraph_node).to eq_paragraph_node create_paragraph_node(
+        sentences: [
+          create_sentence_node(words: [
+            create_node(type: 'TEXT', value: '-', consumed: 1),
+            create_node(type: 'TEXT', value: ' blah blah', consumed: 1)
+          ], consumed: 3)
+        ],
+        consumed: 3
+      )
+    end
+
     it "can parse paragraph" do
       parser = create_parser(:paragraph_parser)
 

--- a/spec/token_list_spec.rb
+++ b/spec/token_list_spec.rb
@@ -24,12 +24,13 @@ describe Md2Html::Tokenizer::TokenList do
     expect(token_list.peek_or(%w(UNDERSCORE TEXT UNDERSCORE), %w(TEXT))).to eq true
   end
 
-  it "peek_or() dash" do
-    token_list = Md2Html::Tokenizer::tokenize('-')
-    expect(token_list.peek_or(%w(DASH))).to eq true
+  it "peek_or() returns true when given token types match in order, and only part of it" do
+    token_list = Md2Html::Tokenizer::tokenize('_Foo_')
+    expect(token_list.peek_or(%w(TEXT))).to eq false
+    expect(token_list.peek_or(%w(UNDERSCORE TEXT))).to eq true
   end
 
-  it "peek_from() needs token position to check" do
+  it "peek_from() specifies the position of token to match" do
     token_list = Md2Html::Tokenizer::tokenize('_Foo_')
     expect(token_list.peek_from(1, 'TEXT')).to eq true
     expect(token_list.peek_from(2, 'UNDERSCORE')).to eq true
@@ -51,14 +52,14 @@ describe Md2Html::Tokenizer::TokenList do
 
   it "grab raise error when token count exceeds total token count" do
     token_list = Md2Html::Tokenizer::tokenize('_Foo_')
-    expect { token_list.grab!(5) }.to raise_error(RuntimeError) # _Foo_ has 5 tokens, the last of which is EOF.
+    expect { token_list.grab!(5) }.to raise_error(RuntimeError) # _Foo_ has 4 tokens, the last of which is EOF.
   end
 
   it "offset() returns new tokenlist starts from nth token" do
     token_list = Md2Html::Tokenizer::tokenize('_Foo_')
-    n = 1
-    expect(token_list.offset(n).tokens[0].value).to eq 'Foo'
-    expect(token_list.offset(n).tokens[1].value).to eq '_'
-    expect(token_list.offset(n).tokens[2].value).to eq ''
+    offset_from_1th = token_list.offset(1)
+    expect(offset_from_1th.tokens[0].value).to eq 'Foo'
+    expect(offset_from_1th.tokens[1].value).to eq '_'
+    expect(offset_from_1th.tokens[2].value).to eq ''
   end
 end

--- a/spec/tokenizer_spec.rb
+++ b/spec/tokenizer_spec.rb
@@ -101,4 +101,14 @@ And this is another para.")
       create_token(type: 'EOF', value: '')
     ]))
   end
+
+  it "can make token of non-special char when backslash exists before the char" do
+    all_token_list = []
+    ['\-', '\#', '\_', '\*'].each {|s| all_token_list << tokenize(s)}
+
+    expect(all_token_list[0].peek_or(%w(ESCAPE DASH))).to eq true
+    expect(all_token_list[1].peek_or(%w(ESCAPE HASH))).to eq true
+    expect(all_token_list[2].peek_or(%w(ESCAPE UNDERSCORE))).to eq true
+    expect(all_token_list[3].peek_or(%w(ESCAPE STAR))).to eq true
+  end
 end

--- a/spec/tokenizer_spec.rb
+++ b/spec/tokenizer_spec.rb
@@ -11,6 +11,14 @@ def tokenize plain_text
   Md2Html::Tokenizer::tokenize plain_text
 end
 
+def tokens_as_array plain_text
+  Md2Html::Tokenizer::tokens_as_array plain_text
+end
+
+def merge_chars2escape plain_text
+  Md2Html::Tokenizer::merge_chars2escape plain_text
+end
+
 def create_token attrs
   Md2Html::Tokenizer::Token.new attrs
 end
@@ -104,11 +112,18 @@ And this is another para.")
 
   it "can make token of non-special char when backslash exists before the char" do
     all_token_list = []
-    ['\-', '\#', '\_', '\*'].each {|s| all_token_list << tokenize(s)}
+    ['\-', '\#', '\_', '\*'].each {|s| all_token_list << tokens_as_array(s)}
 
-    expect(all_token_list[0].peek_or(%w(ESCAPE DASH))).to eq true
-    expect(all_token_list[1].peek_or(%w(ESCAPE HASH))).to eq true
-    expect(all_token_list[2].peek_or(%w(ESCAPE UNDERSCORE))).to eq true
-    expect(all_token_list[3].peek_or(%w(ESCAPE STAR))).to eq true
+    expect(all_token_list[0].map {|t| t.type}).to eq ['ESCAPE', 'DASH', 'EOF']
+    expect(all_token_list[1].map {|t| t.type}).to eq ['ESCAPE', 'HASH', 'EOF']
+    expect(all_token_list[2].map {|t| t.type}).to eq ['ESCAPE', 'UNDERSCORE', 'EOF']
+    expect(all_token_list[3].map {|t| t.type}).to eq ['ESCAPE', 'STAR', 'EOF']
+  end
+
+  it "tokens_as_array() merges escape char and trailing special char" do
+    token_list = ('\-')
+    taa = tokens_as_array token_list
+    res = merge_chars2escape taa
+    expect(res[0].type).to eq 'TEXT'
   end
 end

--- a/test/data/escape/escape.html
+++ b/test/data/escape/escape.html
@@ -1,3 +1,12 @@
 <p>
   foo - bar
 </p>
+<p>
+  **foobar
+</p>
+<p>
+  --barbaz
+</p>
+<p>
+  #foo
+</p>

--- a/test/data/escape/escape.md
+++ b/test/data/escape/escape.md
@@ -1,1 +1,7 @@
 foo - bar
+
+\*\*foobar
+
+\-\-barbaz
+
+\#foo

--- a/test/run_tests.rb
+++ b/test/run_tests.rb
@@ -3,7 +3,10 @@ require 'test/unit'
 
 include Test::Unit::Assertions
 
-paths = ['bold/bold', 'paragraph/one_para', 'paragraph/one_para_with_br', 'paragraph/two_para', 'list/list', 'escape/escape', 'heading/level_1']
+paths = [
+  'bold/bold', 'paragraph/one_para', 'paragraph/one_para_with_br', 'paragraph/two_para',
+  'list/list', 'escape/escape', 'heading/level_1', 'heading/level_2'
+]
 paths.each do |path|
   # 마크다운 포맷 테스트 데이터를 읽어온다
   # 읽어온 데이터에 md2html.make_html 메서드를 적용한다


### PR DESCRIPTION
마크다운 태그에서 쓰는 특수 문자 앞에 \ 문자를 붙이면 해당 문자를 escape 처리할 수 있다