### PR TITLE
같은 위계의 node 구조를 일관적으로 바꾼다

### DIFF
--- a/lib/md2html/generator/heading_visitor.rb
+++ b/lib/md2html/generator/heading_visitor.rb
@@ -2,10 +2,11 @@ module Md2Html
   module Generator
     class HeadingVisitor
       def visit(heading_node)
+        heading_value = heading_node.sentences.first.words.first.value
         if heading_node.type == "HEADING"
-          "<h1>#{heading_node.value}</h1>"
+          "<h1>#{heading_value}</h1>"
         elsif heading_node.type == "HEADING_LEVEL2"
-          "<h2>#{heading_node.value}</h2>"
+          "<h2>#{heading_value}</h2>"
         end
       end
     end

--- a/lib/md2html/generator/list_item_visitor.rb
+++ b/lib/md2html/generator/list_item_visitor.rb
@@ -2,7 +2,7 @@ module Md2Html
   module Generator
     class ListItemVisitor
       def visit(list_item_node)
-        "<li>#{list_item_node.value.strip}</li>"
+        "<li>#{list_item_node.words.first.value.strip}</li>"
       end
     end
   end

--- a/lib/md2html/parser/body_node.rb
+++ b/lib/md2html/parser/body_node.rb
@@ -1,8 +1,9 @@
 module Md2Html
   module Parser
     class BodyNode
-      attr_reader :blocks, :consumed
+      attr_reader :type, :blocks, :consumed
       def initialize(blocks:, consumed:)
+        @type = 'BODY'
         @blocks = blocks
         @consumed  = consumed
       end

--- a/lib/md2html/parser/heading_node.rb
+++ b/lib/md2html/parser/heading_node.rb
@@ -1,0 +1,31 @@
+module Md2Html
+  module Parser
+    class HeadingNode
+      attr_reader :type, :sentences, :consumed
+      def initialize(type:, sentences:, consumed:)
+        @type = type
+        @sentences = sentences
+        @consumed  = consumed
+      end
+
+      def to_s
+        if self.sentences.size < 1
+          return 'EMPTY HEADING'
+        end
+        result = "#{self.type}:#{self.consumed}\n"
+        self.sentences.each do |sentence|
+          result += "  #{sentence.to_s}\n"
+        end
+        result
+      end
+
+      def present?
+        true
+      end
+
+      def null?
+        false
+      end
+    end
+  end
+end

--- a/lib/md2html/parser/heading_parser.rb
+++ b/lib/md2html/parser/heading_parser.rb
@@ -1,6 +1,6 @@
 require_relative 'base_parser'
 require_relative "matches_first"
-require_relative 'node'
+require_relative 'heading_node'
 
 module Md2Html
   module Parser
@@ -23,16 +23,20 @@ module Md2Html
           node_type += '_LEVEL2'
         end
 
+        single_sentence = [
+          SentenceNode.new({
+            words: [Node.new(type: 'TEXT', value: left.first.value, consumed: 1)],
+            consumed: 1
+          })
+        ]
         if left.peek_or(%w(TEXT NEWLINE NEWLINE)) == true
-          Node.new(type: node_type, value: left.first.value, consumed: 3 + hash_count)
+          HeadingNode.new(type: node_type, sentences: single_sentence, consumed: 3 + hash_count)
         elsif left.peek_or(%w(TEXT NEWLINE EOF)) == true
-          Node.new(type: node_type, value: left.first.value, consumed: 3 + hash_count)
+          HeadingNode.new(type: node_type, sentences: single_sentence, consumed: 3 + hash_count)
         elsif left.peek_or(%w(TEXT NEWLINE)) == true
-          Node.new(type: node_type, value: left.first.value, consumed: 2 + hash_count)
+          HeadingNode.new(type: node_type, sentences: single_sentence, consumed: 2 + hash_count)
         end
       end
     end
   end
 end
-
-

--- a/lib/md2html/parser/list_item_parser.rb
+++ b/lib/md2html/parser/list_item_parser.rb
@@ -6,7 +6,11 @@ module Md2Html
     class ListItemParser < BaseParser
       def match(tokens)
         return Node.null unless tokens.peek_or(%w(DASH TEXT NEWLINE))
-        Node.new(type: 'LIST_ITEM', value: tokens.second.value, consumed: 3)
+        SentenceNode.new({
+          type: 'LIST_ITEM',
+          words: [Node.new(type: 'TEXT', value: tokens.second.value, consumed: 1)],
+          consumed: 3
+        })
       end
     end
   end

--- a/lib/md2html/parser/list_node.rb
+++ b/lib/md2html/parser/list_node.rb
@@ -1,11 +1,11 @@
 module Md2Html
   module Parser
     class ListNode
-      attr_reader :sentences, :consumed, :type
+      attr_reader :type, :sentences, :consumed
       def initialize(sentences:, consumed:)
+        @type = 'LIST'
         @sentences = sentences
         @consumed  = consumed
-        @type = 'LIST'
       end
 
       def to_s

--- a/lib/md2html/parser/paragraph_node.rb
+++ b/lib/md2html/parser/paragraph_node.rb
@@ -1,11 +1,11 @@
 module Md2Html
   module Parser
     class ParagraphNode
-      attr_reader :sentences, :consumed, :type
+      attr_reader :type, :sentences, :consumed
       def initialize(sentences:, consumed:)
+        @type = 'PARAGRAPH'
         @sentences = sentences
         @consumed  = consumed
-        @type = 'PARAGRAPH'
       end
 
       def to_s

--- a/lib/md2html/parser/sentence_node.rb
+++ b/lib/md2html/parser/sentence_node.rb
@@ -5,9 +5,9 @@ module Md2Html
       attr_accessor :type
 
       def initialize(options = {})
+        @type = options[:type] || 'SENTENCE'
         @words = options[:words]
         @consumed  = options[:consumed]
-        @type = options[:type] || 'SENTENCE'
       end
 
       def self.ends_early(options = {})

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -87,10 +87,14 @@ describe Md2Html::Parser, "parser" do
       list_nl_eof_token = tokenize("- foo\n")
       expect([parser.match(list_nl_eof_token)].collect{|x| [
         x.type,
-        x.sentences.collect{|s| [s.type, s.value, s.consumed]}.first,
+        x.sentences.collect{|s| [
+          s.type,
+          s.words.collect{|w| [w.type, w.value, w.consumed]}.first,
+          s.consumed
+        ]}.first,
         x.consumed
       ]}.first).to eq(
-        ["LIST", ["LIST_ITEM", " foo", 3], 4]
+        ["LIST", ["LIST_ITEM", ['TEXT', " foo", 1], 3], 4]
       )
     end
 
@@ -100,10 +104,14 @@ describe Md2Html::Parser, "parser" do
       list_nl_nl_eof_token = tokenize("- foo\n\n")
       expect([parser.match(list_nl_nl_eof_token)].collect{|x| [
         x.type,
-        x.sentences.collect{|s| [s.type, s.value, s.consumed]}.first,
+        x.sentences.collect{|s| [
+          s.type,
+          s.words.collect{|w| [w.type, w.value, w.consumed]}.first,
+          s.consumed
+        ]},
         x.consumed
       ]}.first).to eq(
-        ["LIST", ["LIST_ITEM", " foo", 3], 5]
+        ["LIST", [["LIST_ITEM", ['TEXT', " foo", 1], 3]], 5]
       )
     end
 
@@ -113,10 +121,14 @@ describe Md2Html::Parser, "parser" do
       list_nl_list_nl_eof_token = tokenize("- foo\n- bar\n")
       expect([parser.match(list_nl_list_nl_eof_token)].collect{|x| [
         x.type,
-        x.sentences.collect{|s| [s.type, s.value, s.consumed]},
+        x.sentences.collect{|s| [
+          s.type,
+          s.words.collect{|w| [w.type, w.value, w.consumed]}.first,
+          s.consumed
+        ]},
         x.consumed
       ]}.first).to eq(
-        ["LIST", [["LIST_ITEM", " foo", 3], ["LIST_ITEM", " bar", 3]], 7]
+        ["LIST", [["LIST_ITEM", ['TEXT', " foo", 1], 3], ["LIST_ITEM", ['TEXT', " bar", 1], 3]], 7]
       )
     end
   end

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -331,10 +331,15 @@ describe Md2Html::Parser, "parser" do
     parser = create_parser(:heading_parser)
 
     tokens = tokenize("# title\n")
-    node = [parser.match(tokens)].collect {|w| [w.type, w.value, w.consumed]}
+
+    node = [parser.match(tokens)].collect {|w| [
+      w.type,
+      w.sentences.first.words.collect {|w| w.value },
+      w.consumed
+    ]}
 
     expect(node).to eq(
-      [['HEADING', ' title', 4]]
+      [['HEADING', [' title'], 4]]
     )
   end
 
@@ -352,10 +357,14 @@ describe Md2Html::Parser, "parser" do
       parser = create_parser(:block_parser)
 
       tokens = tokenize("# title\n")
-      node = [parser.match(tokens)].collect { |hd| [hd.type, hd.value, hd.consumed] }
+      node = [parser.match(tokens)].collect do |hd| [
+        hd.type,
+        hd.sentences.first.words.collect {|w| w.value},
+        hd.consumed
+      ] end
 
       expect(node).to eq(
-        [['HEADING', ' title', 4]]
+        [['HEADING', [' title'], 4]]
       )
     end
   end
@@ -364,20 +373,28 @@ describe Md2Html::Parser, "parser" do
     it "can parse text that has heading" do
       parser = create_parser(:heading_parser)
       tokens = tokenize("# title\n")
-      node = [parser.match(tokens)].collect { |hd| [hd.type, hd.value, hd.consumed] }
+      node = [parser.match(tokens)].collect do |hd| [
+        hd.type,
+        hd.sentences.first.words.collect {|w| w.value},
+        hd.consumed
+      ] end
 
       expect(node).to eq(
-        [['HEADING', ' title',4]]
+        [['HEADING', [' title'],4]]
       )
     end
 
     it "can parse text that has level 2 heading" do
       parser = create_parser(:heading_parser)
       tokens = tokenize("## title\n")
-      node = [parser.match(tokens)].collect { |hd| [hd.type, hd.value, hd.consumed] }
+      node = [parser.match(tokens)].collect do |hd| [
+        hd.type,
+        hd.sentences.first.words.collect {|w| w.value},
+        hd.consumed
+      ] end
 
       expect(node).to eq(
-        [['HEADING_LEVEL2', ' title', 5]]
+        [['HEADING_LEVEL2', [' title'], 5]]
       )
     end
   end
@@ -502,21 +519,31 @@ describe Md2Html::Parser, "parser" do
     it "can parse text that has heading" do
       tokens = tokenize("# title\n")
       node = [parse(tokens)].collect do |body| [
-        body.blocks.collect { |n| [n.type, n.value, n.consumed] }.first,
+        body.blocks.collect do |n| [
+          n.type,
+          n.sentences.first.words.collect {|w| w.value},
+          n.consumed
+        ]
+        end.first,
         body.consumed
       ] end.first
 
-      expect(node).to eq([["HEADING", " title", 4], 4])
+      expect(node).to eq([["HEADING", [" title"], 4], 4])
     end
 
     it "can parse text that has level 2 heading" do
       tokens = tokenize("## title\n")
       node = [parse(tokens)].collect do |body| [
-        body.blocks.collect { |n| [n.type, n.value, n.consumed] }.first,
+        body.blocks.collect do |n| [
+          n.type,
+          n.sentences.first.words.collect {|w| w.value},
+          n.consumed
+        ]
+        end.first,
         body.consumed
       ] end.first
 
-      expect(node).to eq([["HEADING_LEVEL2", " title", 5], 5])
+      expect(node).to eq([["HEADING_LEVEL2", [" title"], 5], 5])
     end
 
     it "can parse text that has heading and another" do

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -19,26 +19,6 @@ def create_parser name
   Md2Html::Parser::ParserFactory.build(name)
 end
 
-def create_node attrs
-  Md2Html::Parser::Node.new attrs
-end
-
-def create_sentence_node attrs
-  Md2Html::Parser::SentenceNode.new attrs
-end
-
-def create_paragraph_node attrs
-  Md2Html::Parser::ParagraphNode.new attrs
-end
-
-def create_list_node attrs
-  Md2Html::Parser::ListNode.new attrs
-end
-
-def create_body_node attrs
-  Md2Html::Parser::BodyNode.new attrs
-end
-
 def parse tokens
   Md2Html::Parser::parse tokens
 end

--- a/spec/tokenizer_spec.rb
+++ b/spec/tokenizer_spec.rb
@@ -19,18 +19,6 @@ def merge_chars2escape plain_text
   Md2Html::Tokenizer::merge_chars2escape plain_text
 end
 
-def create_token attrs
-  Md2Html::Tokenizer::Token.new attrs
-end
-
-def create_eof_token
-  Md2Html::Tokenizer::Token.end_of_file
-end
-
-def create_token_list tokens
-  Md2Html::Tokenizer::TokenList.new tokens
-end
-
 describe Md2Html::Tokenizer do
   it "tokenize text" do
     tokens = tokenize('Hi')


### PR DESCRIPTION
- block_node에 해당하는 heading_node, list_node, paragraph_node가 모두 하위 노드로 sentence_node 타입 node를 갖도록 구조를 정리한다
- 테스트에 변경 사항을 반영한다