### PR TITLE
backtick escape 파싱 에러를 해결한다

### DIFF
--- a/spec/tokenizer_spec.rb
+++ b/spec/tokenizer_spec.rb
@@ -184,6 +184,34 @@ And this is another para.")
     )
   end
 
+  it "merge_inline_code_chars() ignores 1 escaped backtick pair" do
+    token_list = tokens_as_array('\`ls\`')
+    expect(
+      merge_inline_code_chars(token_list).collect {|x| [x.type, x.value]}
+    ).to eq(
+      [
+        ["ESCAPE", "\\"], ["BACKTICK", "`"],
+        ["TEXT", "ls"], ["ESCAPE", "\\"],
+        ["BACKTICK", "`"], ["EOF", ""]
+      ]
+    )
+  end
+
+  it "merge_inline_code_chars() ignores only escaped backtick pair" do
+    token_list = tokens_as_array('\`ls\` `cat`')
+    expect(
+      merge_inline_code_chars(token_list).collect {|x| [x.type, x.value]}
+    ).to eq(
+      [
+        ["ESCAPE", "\\"], ["BACKTICK", "`"],
+        ["TEXT", "ls"], ["ESCAPE", "\\"],
+        ["BACKTICK", "`"], ["TEXT", " "],
+        ["CODE", 'cat'], ["EOF", ""]
+      ]
+    )
+  end
+
+
   it "check_list_mark() converts list mark token's type" do
     token_list = tokens_as_array("foo - bar\n- baz")
     expect(check_list_mark(token_list).collect {|x| [x.type, x.value]}).to eq(


### PR DESCRIPTION
 - backtick 문자를 리터럴로 쓰려고 할 때도 backtick 문자 쌍으로 감싸진 범위의 문자열을 인라인 코드 토큰으로 바꾸고 있었다
 - escape 문자가 앞에 있는 backtick 쌍은 인라인 코드 토큰으로 바꾸는 대신 escape를 적용한다