### PR TITLE
개행 문자를 연속으로 입력 가능하게 한다

### DIFF
--- a/lib/md2html/parser/sentence_parser.rb
+++ b/lib/md2html/parser/sentence_parser.rb
@@ -13,15 +13,19 @@ module Md2Html
         return Node.null if nodes.empty?
 
         case
-        when tokens.peek_from(consumed, 'NEWLINE', 'NEWLINE', 'EOF') == true
-          consumed += 3
         when tokens.peek_from(consumed, 'NEWLINE', 'NEWLINE') == true
           newline_count = 2
           while tokens.peek_from(consumed + newline_count, 'NEWLINE') == true
             newline_count += 1
           end
-          consumed += newline_count
-          return SentenceNode.ends_early({words: nodes, consumed: consumed})
+
+          # 단락의 끝일 경우
+          if tokens.peek_from(consumed + newline_count, 'EOF') == false
+            consumed += newline_count
+            return SentenceNode.ends_early({words: nodes, consumed: consumed})
+          end
+          # 문서 전체의 끝일 경우
+          consumed += newline_count + 1  # +1 for EOF
         when tokens.peek_from(consumed, 'NEWLINE', 'EOF') == true
           consumed += 2
         when tokens.peek_from(consumed, 'NEWLINE') == true

--- a/lib/md2html/parser/sentence_parser.rb
+++ b/lib/md2html/parser/sentence_parser.rb
@@ -16,7 +16,11 @@ module Md2Html
         when tokens.peek_from(consumed, 'NEWLINE', 'NEWLINE', 'EOF') == true
           consumed += 3
         when tokens.peek_from(consumed, 'NEWLINE', 'NEWLINE') == true
-          consumed += 2
+          newline_count = 2
+          while tokens.peek_from(consumed + newline_count, 'NEWLINE') == true
+            newline_count += 1
+          end
+          consumed += newline_count
           return SentenceNode.ends_early({words: nodes, consumed: consumed})
         when tokens.peek_from(consumed, 'NEWLINE', 'EOF') == true
           consumed += 2

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -248,6 +248,33 @@ describe Md2Html::Parser, "parser" do
       )
     end
 
+    it "can parse sentence followed by three or more newlines ends with EOF" do
+      parser = create_parser(:sentence_parser)
+      expected_words = [
+        ['TEXT', 'Hello', 1]
+      ]
+
+      tokens_3nl_eof = tokenize("Hello\n\n\n")
+      sentence_node = [parser.match(tokens_3nl_eof)].collect{|x| [
+        x.type,
+        x.words.collect{|w| [w.type, w.value, w.consumed]},
+        x.consumed
+      ]}.first
+      expect(sentence_node).to eq(
+        ["SENTENCE", expected_words, 5]
+      )
+
+      tokens_5nl_eof = tokenize("Hello\n\n\n\n\n")
+      sentence_node = [parser.match(tokens_5nl_eof)].collect{|x| [
+        x.type,
+        x.words.collect{|w| [w.type, w.value, w.consumed]},
+        x.consumed
+      ]}.first
+      expect(sentence_node).to eq(
+        ["SENTENCE", expected_words, 7]
+      )
+    end
+
     it "can parse one sentence without eof in mind" do
       parser = create_parser(:sentence_parser)
       expected_words = [

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -221,6 +221,33 @@ describe Md2Html::Parser, "parser" do
       )
     end
 
+    it "can parse sentence followed by three or more newlines" do
+      parser = create_parser(:sentence_parser)
+      expected_words = [
+        ['TEXT', 'Hello', 1]
+      ]
+
+      tokens_3nl = tokenize("Hello\n\n\nWorld")
+      sentence_node = [parser.match(tokens_3nl)].collect{|x| [
+        x.type,
+        x.words.collect{|w| [w.type, w.value, w.consumed]},
+        x.consumed
+      ]}.first
+      expect(sentence_node).to eq(
+        ["SENTENCE_ENDS_EARLY", expected_words, 4]
+      )
+
+      tokens_5nl = tokenize("Hello\n\n\n\n\nWorld")
+      sentence_node = [parser.match(tokens_5nl)].collect{|x| [
+        x.type,
+        x.words.collect{|w| [w.type, w.value, w.consumed]},
+        x.consumed
+      ]}.first
+      expect(sentence_node).to eq(
+        ["SENTENCE_ENDS_EARLY", expected_words, 6]
+      )
+    end
+
     it "can parse one sentence without eof in mind" do
       parser = create_parser(:sentence_parser)
       expected_words = [

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -644,6 +644,48 @@ describe Md2Html::Parser, "parser" do
         [['HEADING_LEVEL2', ['SENTENCE', [['TEXT', ' title', 1]], 1], 5]]
       )
     end
+
+    it "can parse heading followed by three or more newlines" do
+      parser = create_parser(:heading_parser)
+
+      # consumed = 2 HASH + 1 TEXT + 3 NEWLINE + 1 EOF = 7
+      tokens_3nl = tokenize("## title\n\n\n")
+      node = [parser.match(tokens_3nl)].collect do |x|
+        s = x.sentences.first
+        [
+          x.type,
+          [
+            s.type,
+            s.words.collect { |w| [w.type, w.value, w.consumed] },
+            s.consumed
+          ],
+          x.consumed
+        ]
+      end
+
+      expect(node).to eq(
+        [['HEADING_LEVEL2', ['SENTENCE', [['TEXT', ' title', 1]], 1], 7]]
+      )
+
+      # consumed = 2 HASH + 1 TEXT + 5 NEWLINE + 1 EOF = 9
+      tokens_5nl = tokenize("## title\n\n\n\n\n")
+      node = [parser.match(tokens_5nl)].collect do |x|
+        s = x.sentences.first
+        [
+          x.type,
+          [
+            s.type,
+            s.words.collect { |w| [w.type, w.value, w.consumed] },
+            s.consumed
+          ],
+          x.consumed
+        ]
+      end
+
+      expect(node).to eq(
+        [['HEADING_LEVEL2', ['SENTENCE', [['TEXT', ' title', 1]], 1], 9]]
+      )
+    end
   end
 
   context "body parser" do

--- a/spec/token_list_spec.rb
+++ b/spec/token_list_spec.rb
@@ -37,7 +37,7 @@ describe Md2Html::Tokenizer::TokenList do
 
   it "peek_or() for list item whose text has dash char" do
     list_item_tokens = Md2Html::Tokenizer::tokenize("- fo-o\n")
-    list_item_tokens.peek_or(%w(DASH TEXT NEWLINE))
+    expect(list_item_tokens.peek_or(%w(LIST_MARK TEXT DASH TEXT NEWLINE))).to eq true
   end
 
   it "peek_from() specifies the position of token to match" do

--- a/spec/tokenizer_spec.rb
+++ b/spec/tokenizer_spec.rb
@@ -113,7 +113,11 @@ And this is another para.")
 
   it "can make token of non-special char when backslash exists before the char" do
     token_lists = ['\-', '\#', '\_', '\*'].collect{|w| tokens_as_array(w)}
-    expect(token_lists.collect {|x| x.collect {|x| [x.type, x.value]}}).to eq(
+    expect(token_lists.collect { |token_list|
+      token_list.collect { |x|
+        [x.type, x.value]
+      }
+    }).to eq(
       [
         [["ESCAPE", "\\"], ["DASH", "-"], ["EOF", ""]],
         [["ESCAPE", "\\"], ["HASH", "#"], ["EOF", ""]],

--- a/test/data/paragraph/multiple_newlines.html
+++ b/test/data/paragraph/multiple_newlines.html
@@ -1,0 +1,9 @@
+<p>
+  First paragraph.
+</p>
+<p>
+  Second paragraph.
+</p>
+<p>
+  Third paragraph.
+</p>

--- a/test/data/paragraph/multiple_newlines.md
+++ b/test/data/paragraph/multiple_newlines.md
@@ -1,0 +1,8 @@
+First paragraph.
+
+
+Second paragraph.
+
+
+
+Third paragraph.

--- a/test/run_tests.rb
+++ b/test/run_tests.rb
@@ -5,8 +5,8 @@ include Test::Unit::Assertions
 
 paths = [
   'bold/bold', 'paragraph/one_para', 'paragraph/one_para_with_br', 'paragraph/two_para',
-  'paragraph/inline_code', 'list/list', 'escape/escape', 'heading/level_1', 'heading/level_2',
-  'list/list_2', 'list/list_3'
+  'paragraph/inline_code', 'paragraph/multiple_newlines', 'list/list', 'escape/escape',
+  'heading/level_1', 'heading/level_2', 'list/list_2', 'list/list_3'
 ]
 paths.each do |path|
   # 마크다운 포맷 테스트 데이터를 읽어온다


### PR DESCRIPTION
기존 구현은 개행 문자를 두 개까지만 처리할 수 있도록 구현되어 있었다.
이에 따라, 문서 작성 시 개행 문자를 세 개 이상 쓰려면 개행 문자 두 개 뒤마다 \ 문자를 쓰는 식으로 지저분하게 처리해야 했다.
이 문제를 해결하기 위해 개행 문자를 연속해서 세 개 이상도 쓸 수 있도록 수정한다.
